### PR TITLE
Improve folder generator editor tooling

### DIFF
--- a/FolderStructureGenerator/CreateFolders.cs
+++ b/FolderStructureGenerator/CreateFolders.cs
@@ -1,7 +1,8 @@
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor
+namespace UnityFolderGenerator.Editor
 {
     /// <summary>
     /// The Editor Window for the Folder Structure Generator.
@@ -15,8 +16,12 @@ namespace Editor
         
         private string projectName = "";
         private FolderStructureConfig config;
+        private int cachedConfigVersion = -1;
+        private Dictionary<string, List<string>> cachedMainFolderStructure = new Dictionary<string, List<string>>();
+        private List<string> cachedStandaloneFolders = new List<string>();
         private Vector2 scrollPosition;
         private bool showAdvancedOptions;
+        private string lastGenerationSummary = string.Empty;
     
         /// <summary>
         /// Creates the menu item in the Unity Editor to open this window.
@@ -69,17 +74,22 @@ namespace Editor
         {
             EditorGUILayout.LabelField("Configuration File:", EditorStyles.boldLabel);
             FolderStructureConfig newConfig = (FolderStructureConfig)EditorGUILayout.ObjectField("Folder Config", config, typeof(FolderStructureConfig), false);
-        
+
             // When the user assigns a new config file
             if (newConfig != config)
             {
                 config = newConfig;
+                cachedConfigVersion = -1;
+                RefreshCachedFolderData();
+                lastGenerationSummary = string.Empty;
                 // If the project name field is empty, populate it with the default from the config
                 if (config != null && string.IsNullOrEmpty(projectName))
                 {
                     projectName = config.defaultProjectName;
                 }
             }
+
+            EnsureCacheIsCurrent();
         }
 
         private void DrawAdvancedOptions()
@@ -91,17 +101,18 @@ namespace Editor
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.LabelField("Configuration Preview:", EditorStyles.boldLabel);
-            
-                var mainFolderStructure = config.GetMainFolderStructure();
-                var standaloneFolders = config.GetStandaloneFolders();
-                
+
                 GUIContent folderIcon = EditorGUIUtility.IconContent("Folder Icon");
                 GUIContent subfolderIcon = EditorGUIUtility.IconContent("FolderEmpty Icon");
 
-                EditorGUILayout.LabelField(new GUIContent($" {projectName}", folderIcon.image));
+                string previewProjectName = string.IsNullOrWhiteSpace(projectName) && config != null
+                    ? config.defaultProjectName
+                    : projectName;
+
+                EditorGUILayout.LabelField(new GUIContent($" {previewProjectName}", folderIcon.image));
                 EditorGUI.indentLevel++;
-                
-                foreach (var folder in mainFolderStructure)
+
+                foreach (var folder in cachedMainFolderStructure)
                 {
                     EditorGUILayout.LabelField(new GUIContent($" {folder.Key}", folderIcon.image));
                     if (folder.Value.Count > 0)
@@ -114,12 +125,11 @@ namespace Editor
                         EditorGUI.indentLevel--;
                     }
                 }
-                
+
                 EditorGUI.indentLevel--;
-                
-                foreach (var folder in standaloneFolders)
+
+                foreach (var folder in cachedStandaloneFolders)
                 {
-                     if (string.IsNullOrWhiteSpace(folder)) continue;
                     EditorGUILayout.LabelField(new GUIContent($" {folder}", folderIcon.image));
                 }
             
@@ -132,7 +142,12 @@ namespace Editor
             GUILayout.Space(10);
             string infoText = $"This will create folders based on the selected configuration.\n";
             infoText += $"Git keep files: {(config.createGitKeepFiles ? "Enabled" : "Disabled")}\n";
-            infoText += $"Total folder groups: {config.folderGroups.FindAll(g => g.enabled).Count}";
+            infoText += $"Total folder groups: {cachedMainFolderStructure.Count}";
+
+            if (!string.IsNullOrEmpty(lastGenerationSummary))
+            {
+                infoText += $"\nLast run: {lastGenerationSummary}";
+            }
             EditorGUILayout.HelpBox(infoText, MessageType.Info);
         }
 
@@ -150,11 +165,48 @@ namespace Editor
             GUI.enabled = FolderGenerator.IsValidFolderName(projectName) && config != null;
             if (GUILayout.Button("Generate Folders!", GUILayout.Height(30)))
             {
-                FolderGenerator.CreateAllFolders(config, projectName);
+                FolderGenerator.FolderGenerationResult result = FolderGenerator.CreateAllFolders(config, projectName);
+                if (!string.IsNullOrEmpty(result.Message))
+                {
+                    lastGenerationSummary = result.Message;
+                }
             }
             GUI.enabled = true;
-        
+
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void EnsureCacheIsCurrent()
+        {
+            if (config == null)
+            {
+                cachedMainFolderStructure.Clear();
+                cachedStandaloneFolders.Clear();
+                cachedConfigVersion = -1;
+                return;
+            }
+
+            if (cachedConfigVersion == config.Version)
+            {
+                return;
+            }
+
+            RefreshCachedFolderData();
+        }
+
+        private void RefreshCachedFolderData()
+        {
+            if (config == null)
+            {
+                cachedMainFolderStructure.Clear();
+                cachedStandaloneFolders.Clear();
+                cachedConfigVersion = -1;
+                return;
+            }
+
+            cachedMainFolderStructure = config.GetMainFolderStructure();
+            cachedStandaloneFolders = config.GetStandaloneFolders();
+            cachedConfigVersion = config.Version;
         }
     }
 }

--- a/FolderStructureGenerator/FolderGenerator.cs
+++ b/FolderStructureGenerator/FolderGenerator.cs
@@ -2,7 +2,7 @@ using System.IO;
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor
+namespace UnityFolderGenerator.Editor
 {
     /// <summary>
     /// Contains the core logic for creating folder structures.
@@ -10,28 +10,29 @@ namespace Editor
     /// </summary>
     public static class FolderGenerator
     {
-        private const string AssetsPath = "Assets";
-
         /// <summary>
         /// Creates the complete folder structure based on the provided configuration and project name.
         /// </summary>
         /// <param name="config">The ScriptableObject configuration for the folders.</param>
         /// <param name="projectName">The root name for the project's main folder.</param>
-        public static void CreateAllFolders(FolderStructureConfig config, string projectName)
+        public static FolderGenerationResult CreateAllFolders(FolderStructureConfig config, string projectName)
         {
             if (!IsValidFolderName(projectName))
             {
-                EditorUtility.DisplayDialog("Invalid Project Name", "Please enter a valid project name without special characters.", "OK");
-                return;
+                const string message = "Please enter a valid project name without special characters.";
+                EditorUtility.DisplayDialog("Invalid Project Name", message, "OK");
+                return FolderGenerationResult.Failure(message);
             }
-        
+
             var mainFolderStructure = config.GetMainFolderStructure();
             var standaloneFolders = config.GetStandaloneFolders(); // Directly use the list from the config
-            int totalFoldersCreated = 0;
-            
+            int createdFolders = 0;
+            int skippedFolders = 0;
+
             try
             {
-                string projectRootPath = Path.Combine(AssetsPath, projectName);
+                string assetsAbsolutePath = GetAssetsAbsolutePath();
+                string projectRootPath = Path.Combine(assetsAbsolutePath, projectName);
                 foreach (var folder in mainFolderStructure)
                 {
                     if (!IsValidFolderName(folder.Key)) continue;
@@ -39,17 +40,25 @@ namespace Editor
                     string mainFolderPath = Path.Combine(projectRootPath, folder.Key);
                     if (CreateDirectoryAndKeep(mainFolderPath, config.createGitKeepFiles && folder.Value.Count == 0))
                     {
-                        totalFoldersCreated++;
+                        createdFolders++;
+                    }
+                    else
+                    {
+                        skippedFolders++;
                     }
 
                     foreach (string subfolder in folder.Value)
-                    {   
+                    {
                         if (!IsValidFolderName(subfolder)) continue;
 
                         string subFolderPath = Path.Combine(mainFolderPath, subfolder);
                         if (CreateDirectoryAndKeep(subFolderPath, config.createGitKeepFiles))
                         {
-                            totalFoldersCreated++;
+                            createdFolders++;
+                        }
+                        else
+                        {
+                            skippedFolders++;
                         }
                     }
                 }
@@ -58,23 +67,48 @@ namespace Editor
                 {
                     if (!IsValidFolderName(folder)) continue;
 
-                    string standaloneFolderPath = Path.Combine(AssetsPath, folder);
+                    string standaloneFolderPath = Path.Combine(assetsAbsolutePath, folder);
                     if (CreateDirectoryAndKeep(standaloneFolderPath, config.createGitKeepFiles))
                     {
-                        totalFoldersCreated++;
+                        createdFolders++;
+                    }
+                    else
+                    {
+                        skippedFolders++;
                     }
                 }
-            
+
                 AssetDatabase.Refresh();
-                EditorUtility.DisplayDialog("Success", $"Successfully created {totalFoldersCreated} folders for '{projectName}'!", "OK");
+                string summary = BuildSummaryMessage(projectName, createdFolders, skippedFolders);
+                EditorUtility.DisplayDialog("Success", summary, "OK");
+                return FolderGenerationResult.Success(projectName, createdFolders, skippedFolders, summary);
             }
             catch (System.Exception e)
             {
                 Debug.LogError($"Failed to create folder structure: {e.Message}");
-                EditorUtility.DisplayDialog("Error", $"Failed to create folders: {e.Message}", "OK");
+                string errorMessage = $"Failed to create folders: {e.Message}";
+                EditorUtility.DisplayDialog("Error", errorMessage, "OK");
+                return FolderGenerationResult.Failure(errorMessage);
             }
         }
-    
+
+        private static string BuildSummaryMessage(string projectName, int createdFolders, int skippedFolders)
+        {
+            string folderWord = createdFolders == 1 ? "folder" : "folders";
+            string summary = $"Created {createdFolders} {folderWord} for '{projectName}'.";
+            if (skippedFolders > 0)
+            {
+                summary += $" Skipped {skippedFolders} existing folder{(skippedFolders == 1 ? string.Empty : "s")}.";
+            }
+
+            if (createdFolders == 0 && skippedFolders == 0)
+            {
+                summary = $"No folders were created for '{projectName}'.";
+            }
+
+            return summary;
+        }
+
         /// <summary>
         /// Creates a directory at the given path and optionally adds a .gitkeep file.
         /// It checks if the directory already exists.
@@ -86,11 +120,12 @@ namespace Editor
         {
             if (Directory.Exists(path))
             {
+                Debug.Log($"Skipped existing folder: {ToRelativeAssetsPath(path)}");
                 return false;
             }
-            
+
             Directory.CreateDirectory(path);
-            Debug.Log($"Created folder: {path}");
+            Debug.Log($"Created folder: {ToRelativeAssetsPath(path)}");
 
             if (createGitKeep)
             {
@@ -113,10 +148,57 @@ namespace Editor
         {
             if (string.IsNullOrWhiteSpace(name))
                 return false;
-            
+
             // GetInvalidFileNameChars() returns characters that cannot be used in a folder/file name
             char[] invalidChars = Path.GetInvalidFileNameChars();
             return name.IndexOfAny(invalidChars) < 0;
+        }
+
+        private static string GetAssetsAbsolutePath()
+        {
+            return Application.dataPath;
+        }
+
+        private static string ToRelativeAssetsPath(string absolutePath)
+        {
+            string normalizedPath = absolutePath.Replace('\\', '/');
+            string normalizedAssetsPath = GetAssetsAbsolutePath().Replace('\\', '/');
+
+            if (normalizedPath.StartsWith(normalizedAssetsPath))
+            {
+                string relative = normalizedPath.Substring(normalizedAssetsPath.Length).TrimStart('/');
+                return string.IsNullOrEmpty(relative) ? "Assets" : $"Assets/{relative}";
+            }
+
+            return normalizedPath;
+        }
+
+        public readonly struct FolderGenerationResult
+        {
+            public bool Succeeded { get; }
+            public string ProjectName { get; }
+            public int CreatedFolders { get; }
+            public int SkippedFolders { get; }
+            public string Message { get; }
+
+            private FolderGenerationResult(bool succeeded, string projectName, int createdFolders, int skippedFolders, string message)
+            {
+                Succeeded = succeeded;
+                ProjectName = projectName;
+                CreatedFolders = createdFolders;
+                SkippedFolders = skippedFolders;
+                Message = message;
+            }
+
+            public static FolderGenerationResult Success(string projectName, int createdFolders, int skippedFolders, string message)
+            {
+                return new FolderGenerationResult(true, projectName, createdFolders, skippedFolders, message);
+            }
+
+            public static FolderGenerationResult Failure(string message)
+            {
+                return new FolderGenerationResult(false, string.Empty, 0, 0, message);
+            }
         }
     }
 }

--- a/FolderStructureGenerator/FolderStructureConfig.cs
+++ b/FolderStructureGenerator/FolderStructureConfig.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-namespace Editor
+namespace UnityFolderGenerator.Editor
 {
     [CreateAssetMenu(fileName = "FolderStructureConfig", menuName = "Unity Tools/Folder Structure Config")]
     public class FolderStructureConfig : ScriptableObject
@@ -14,10 +14,15 @@ namespace Editor
         public List<FolderGroup> folderGroups = new List<FolderGroup>();
         [Tooltip("Additional standalone folders to create")]
         public List<string> standaloneFolders = new List<string>();
-    
+
         [Header("Additional Options")]
         [Tooltip("Create .gitkeep files in empty folders for version control")]
         public bool createGitKeepFiles = true;
+
+        [SerializeField, HideInInspector]
+        private int version;
+
+        public int Version => version;
     
         [System.Serializable]
         public class FolderGroup
@@ -64,7 +69,7 @@ namespace Editor
         {
             // The following logic cleans up empty list entries to prevent clutter in the Inspector.
             // It intentionally leaves one empty slot available, allowing the user to easily add a new item.
-        
+
             if (standaloneFolders.Count > 1)
             {
                 int emptyCount = 0;
@@ -98,6 +103,11 @@ namespace Editor
                         }
                     }
                 }
+            }
+
+            unchecked
+            {
+                version++;
             }
         }
     }

--- a/FolderStructureGenerator/Tests/EditMode/FolderGeneratorTests.cs
+++ b/FolderStructureGenerator/Tests/EditMode/FolderGeneratorTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Reflection;
 using NUnit.Framework;
 
-namespace Editor.Tests
+namespace UnityFolderGenerator.Editor.Tests
 {
     [TestFixture]
     public class FolderGeneratorTests

--- a/FolderStructureGenerator/UnityFolderGenerator.Editor.asmdef
+++ b/FolderStructureGenerator/UnityFolderGenerator.Editor.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "UnityFolderGenerator.Editor",
+    "rootNamespace": "UnityFolderGenerator.Editor",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "noEngineReferences": false
+}

--- a/FolderStructureGenerator/UnityFolderGenerator.Editor.asmdef.meta
+++ b/FolderStructureGenerator/UnityFolderGenerator.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8a024e19f1dc42d38bd8f20bf11ee50d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- refactor folder creation to use Application.dataPath, track skipped folders, and return detailed generation results
- polish the editor window with cached previews, whitespace filtering, and last-run summaries
- move scripts under the UnityFolderGenerator.Editor namespace and add an editor-only assembly definition

## Testing
- Not run (Unity Editor tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d820a84fcc8320a0d688d029a8d8e0